### PR TITLE
Protect empty lines

### DIFF
--- a/bin/ts-to-jsdoc.ts
+++ b/bin/ts-to-jsdoc.ts
@@ -74,10 +74,6 @@ for (const filepath of paths) {
 
 	const code = fs.readFileSync(filepath, "utf8");
 	const transpiled = transpile(code, filepath, {}, true);
-	if (transpiled === code) {
-		console.error(error(`Could not transpile ${filepath}.`));
-		continue;
-	}
 
 	fs.writeFileSync(outPath, transpiled);
 }

--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,7 @@ import type {
 declare module "ts-morph" {
 	// eslint-disable-next-line no-shadow
 	namespace Node {
-		let isObjectProperty: (node: Node) => boolean;
+		//let isObjectProperty: (node: Node) => boolean;
 	}
 }
 Node.isObjectProperty = (node): node is ObjectProperty => (

--- a/index.ts
+++ b/index.ts
@@ -356,7 +356,11 @@ function transpile(
 				);
 			}).join("\n");
 
-			return `${result}\n\n${typedefs}\n\n${interfaces}`;
+			result = `${result}\n\n${typedefs}\n\n${interfaces}`;
+
+			result = result.trim() + "\n";
+
+			return result;
 		}
 		throw new Error("Could not emit output to memory.");
 	} catch (e) {


### PR DESCRIPTION
i just wanted to use ts-to-jsdoc to convert ts-to-jsdoc from typescript to javascript (duh ^^)
but the result is ugly, because empty lines are removed

<details>
<summary>
index.ts with empty lines
</summary>

```ts
import path from "path";

import {
        Project,
        ScriptTarget,
        Node,
} from "ts-morph";

import type {
        ClassDeclaration,
        FunctionLikeDeclaration,
        InterfaceDeclaration,
        JSDoc,
        JSDocableNode,
        MethodDeclaration,
        ModifierableNode,
        PropertyAssignment,
        PropertyDeclaration,
        PropertySignature,
        SourceFile,
        TypeAliasDeclaration,
        TypedNode,
} from "ts-morph";

declare module "ts-morph" {
        // eslint-disable-next-line no-shadow
        namespace Node {
                let isObjectProperty: (node: Node) => boolean;
        }
}
Node.isObjectProperty = (node): node is ObjectProperty => (
        Node.isPropertyDeclaration(node)
        || Node.isPropertyAssignment(node)
        || Node.isPropertySignature(node)
);

type ObjectProperty = JSDocableNode & TypedNode & (
        | PropertyDeclaration
        | PropertyAssignment
        | PropertySignature
);
type ClassMemberNode = JSDocableNode & ModifierableNode & ObjectProperty & MethodDeclaration;

/** Get children for object node */
function getChildProperties(node: Node): ObjectProperty[] {
        const properties = node?.getType()?.getProperties();
        const valueDeclarations = properties.map((child) => child.getValueDeclaration())
                // Hacky way to check if the child is actually a defined child in the interface
                // or if it's, e.g. a built-in method of the type (such as array.length)
                ?.filter((child) => node.getFullText().includes(child?.getFullText()));
        return (valueDeclarations ?? []) as ObjectProperty[];
}

/** Get JSDoc for a node or create one if there isn't any */
function getJsDocOrCreate(node: JSDocableNode): JSDoc {
        return node.getJsDocs()[0] || node.addJsDoc({});
}
```

</details>

<details>
<summary>
index.js with removed empty lines
</summary>

```js
import path from "path";
import { Project, ScriptTarget, Node } from "ts-morph";
Node.isObjectProperty = (node) =>
  Node.isPropertyDeclaration(node) ||
  Node.isPropertyAssignment(node) ||
  Node.isPropertySignature(node);
/**
 * Get children for object node
 * @param {Node} node
 * @returns {any[]}
 */
function getChildProperties(node) {
  const properties = node?.getType()?.getProperties();
  const valueDeclarations = properties
    .map((child) => child.getValueDeclaration())
    // Hacky way to check if the child is actually a defined child in the interface
    // or if it's, e.g. a built-in method of the type (such as array.length)
    ?.filter((child) => node.getFullText().includes(child?.getFullText()));
  return valueDeclarations ?? [];
}
/**
 * Get JSDoc for a node or create one if there isn't any
 * @param {JSDocableNode} node
 * @returns {any}
 */
function getJsDocOrCreate(node) {
  return node.getJsDocs()[0] || node.addJsDoc({});
}
```

</details>


<details>
<summary>
index.js with protected empty lines
</summary>

```js
import path from "path";

import { Project, ScriptTarget, Node, } from "ts-morph";
Node.isObjectProperty = (node) => (Node.isPropertyDeclaration(node)
    || Node.isPropertyAssignment(node)
    || Node.isPropertySignature(node));

/**
 * Get children for object node
 * @param {Node} node
 * @returns {any[]}
 */
function getChildProperties(node) {
    const properties = node?.getType()?.getProperties();
    const valueDeclarations = properties.map((child) => child.getValueDeclaration())
        // Hacky way to check if the child is actually a defined child in the interface
        // or if it's, e.g. a built-in method of the type (such as array.length)
        ?.filter((child) => node.getFullText().includes(child?.getFullText()));
    return (valueDeclarations ?? []);
}

/**
 * Get JSDoc for a node or create one if there isn't any
 * @param {JSDocableNode} node
 * @returns {any}
 */
function getJsDocOrCreate(node) {
    return node.getJsDocs()[0] || node.addJsDoc({});
}
```

</details>

limitation: empty lines before typescript blocks are still removed

<details>
<summary>
example
</summary>

from

```ts
import {
        Project,
        ScriptTarget,
        Node,
} from "ts-morph";

import type {
        ClassDeclaration,
        FunctionLikeDeclaration,
        InterfaceDeclaration,
        JSDoc,
        JSDocableNode,
        MethodDeclaration,
        ModifierableNode,
        PropertyAssignment,
        PropertyDeclaration,
        PropertySignature,
        SourceFile,
        TypeAliasDeclaration,
        TypedNode,
} from "ts-morph";

declare module "ts-morph" {
        // eslint-disable-next-line no-shadow
        namespace Node {
                let isObjectProperty: (node: Node) => boolean;
        }
}
Node.isObjectProperty = (node): node is ObjectProperty => (
        Node.isPropertyDeclaration(node)
        || Node.isPropertyAssignment(node)
        || Node.isPropertySignature(node)
);
```

to

```js
import { Project, ScriptTarget, Node, } from "ts-morph";
Node.isObjectProperty = (node) => (Node.isPropertyDeclaration(node)
    || Node.isPropertyAssignment(node)
    || Node.isPropertySignature(node));
```

</details>

related issues:

- https://stackoverflow.com/questions/53500087/typescript-compiler-api-loses-formatting-during-transformation
- https://stackoverflow.com/questions/51353988/typescript-ast-transformation-removes-all-blank-lines
- https://stackoverflow.com/questions/56889833/create-readable-js-from-typescript
- https://github.com/microsoft/TypeScript/issues/42617