### PR TITLE
Numerous changes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -119,7 +119,7 @@ function generateParameterDocumentation(
 
 		jsDoc.addTag({
 			tagName: preferredTagName || "param",
-			text: `{${parameterType}}${paramName}${comment ? `  ${comment}` : ""}`,
+			text: `{${parameterType}}${paramName}${comment ? ` - ${comment}` : ""}`,
 		});
 	}
 }
@@ -138,11 +138,11 @@ function generateReturnTypeDocumentation(
 	// Replace tag with one that contains type info if tag exists
 	if (returnsTag) {
 		const tagName = returnsTag.getTagName();
-		const comment = returnsTag.getComment();
+		const comment = (returnsTag.getComment() || "").toString().trim().replace(/^[ -]+/, "");
 		// https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#return-type-description
 		if (functionReturnType !== "void") {
 			returnsTag.replaceWithText(
-				`@${tagName} {${functionReturnType}}${comment ? ` ${comment}` : ""}`,
+				`@${tagName} {${functionReturnType}}${comment ? ` - ${comment}` : ""}`,
 			);
 		}
 	} else {

--- a/index.ts
+++ b/index.ts
@@ -96,7 +96,7 @@ function generateParameterDocumentation(
 		.filter((tag) => ["param", "parameter"].includes(tag.getTagName()));
 	const commentLookup = Object.fromEntries(paramTags.map((tag) => [
 		// @ts-ignore
-		tag.compilerNode.name?.getText().replace(/\[|\]/g, "").trim(),
+		tag.compilerNode.name?.getText().replace(/\[|\]|(=.*)/g, "").trim(),
 		(tag.getComment() || "").toString().trim().replace(/^[ -]+/, ""),
 	]));
 	const preferredTagName = paramTags[0]?.getTagName();

--- a/index.ts
+++ b/index.ts
@@ -136,22 +136,16 @@ function generateReturnTypeDocumentation(
 	const returnsTag = (jsDoc?.getTags() || [])
 		.find((tag) => ["returns", "return"].includes(tag.getTagName()));
 	// Replace tag with one that contains type info if tag exists
+	const tagName = returnsTag?.getTagName() || "returns";
+	const comment = (returnsTag?.getComment() || "").toString().trim().replace(/^[ -]+/, "");
+
 	if (returnsTag) {
-		const tagName = returnsTag.getTagName();
-		const comment = (returnsTag.getComment() || "").toString().trim().replace(/^[ -]+/, "");
-		// https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#return-type-description
-		if (functionReturnType !== "void") {
-			returnsTag.replaceWithText(
-				`@${tagName} {${functionReturnType}}${comment ? ` - ${comment}` : ""}`,
-			);
-		}
-	} else {
-		// Otherwise, create a new one
-		jsDoc.addTag({
-			tagName: "returns",
-			text: `{${functionReturnType}}`,
-		});
+		returnsTag.remove();
 	}
+	jsDoc.addTag({
+		tagName,
+		text: `{${functionReturnType}}${comment ? ` - ${comment}` : ""}`,
+	});
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -342,7 +342,7 @@ function transpile(
 					}`,
 				);
 			}
-			result = result.slice(protectCommentsHeader.length);
+			result = result.replace(protectCommentsHeader, "");
 
 			// Restore blank lines in output
 			result = result.split("\n").map((_line) => {

--- a/index.ts
+++ b/index.ts
@@ -54,7 +54,7 @@ function getChildProperties(node: Node): ObjectProperty[] {
 
 /** Get JSDoc for a node or create one if there isn't any */
 function getJsDocOrCreate(node: JSDocableNode): JSDoc {
-	return node.getJsDocs()[0] || node.addJsDoc({});
+	return node.getJsDocs().at(-1) || node.addJsDoc({});
 }
 
 /** Return the node most suitable for JSDoc for a function, adding JSDoc if there isn't any */


### PR DESCRIPTION
This pull request makes 4 changes:

- Fix bug when running in bun (see https://github.com/oven-sh/bun/issues/4217)
- Add support for function expressions, including arrow functions
- Add support for 'optional' params, wrapping the param name with square brackets where applicable, as per the [docs](https://jsdoc.app/tags-param.html#optional-parameters-and-default-values)
- Remove obsolete params from JSDoc (i.e. params that may no longer exist for the function)

Please let me know if you would prefer seperate PRs (if there's reasonable likelihood they'll be merged)

This fork (with these changes) can be used with the [`@jackcannon/ts-to-jsdoc`](https://www.npmjs.com/package/@jackcannon/ts-to-jsdoc) public npm module

