### PR TITLE
Prefer last JSDoc comment

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -53,7 +53,7 @@ function getChildProperties(node: Node): ObjectProperty[] {
 
 /** Get JSDoc for a node or create one if there isn't any */
 function getJsDocOrCreate(node: JSDocableNode): JSDoc {
-	return node.getJsDocs()[0] || node.addJsDoc({});
+	return node.getJsDocs().at(-1) || node.addJsDoc({});
 }
 
 /** Sanitize a string to use as a type in a doc comment so that it is compatible with JSDoc */


### PR DESCRIPTION
In the case of multiple JSDoc comment before the function, prefer the last (and therefore the closest to the function)

### Input
```typescript
/**
 * A random orphan JSDoc comment.
 */
/**
 * Does stuff.
 */
function doStuff(param: string): number {
  return 1;
};
```

### ❌ Before
```typescript
/**
 * A random orphan JSDoc comment.
 * @param {string} param
 * @returns {number}
 */
/**
 * Does stuff.
 */
function doStuff(param) {
    return 1;
}
;
```

### ✅ After
```typescript
/**
 * A random orphan JSDoc comment.
 */
/**
 * Does stuff.
 * @param {string} param
 * @returns {number}
 */
function doStuff(param) {
    return 1;
}
;
```