### PR TITLE
[WIP] Improve the output @param tags

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -119,7 +119,7 @@ function generateParameterDocumentation(
 
 		jsDoc.addTag({
 			tagName: preferredTagName || "param",
-			text: `{${parameterType}}${paramName}${comment ? `  ${comment}` : ""}`,
+			text: `{${parameterType}}${paramName}${comment ? ` - ${comment}` : ""}`,
 		});
 	}
 }
@@ -138,11 +138,11 @@ function generateReturnTypeDocumentation(
 	// Replace tag with one that contains type info if tag exists
 	if (returnsTag) {
 		const tagName = returnsTag.getTagName();
-		const comment = returnsTag.getComment();
+		const comment = (returnsTag.getComment() || "").toString().trim().replace(/^[ -]+/, "");
 		// https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#return-type-description
 		if (functionReturnType !== "void") {
 			returnsTag.replaceWithText(
-				`@${tagName} {${functionReturnType}}${comment ? ` ${comment}` : ""}`,
+				`@${tagName} {${functionReturnType}}${comment ? ` - ${comment}` : ""}`,
 			);
 		}
 	} else {

--- a/index.ts
+++ b/index.ts
@@ -96,7 +96,7 @@ function generateParameterDocumentation(
 		.filter((tag) => ["param", "parameter"].includes(tag.getTagName()));
 	const commentLookup = Object.fromEntries(paramTags.map((tag) => [
 		// @ts-ignore
-		tag.compilerNode.name?.getText().replace(/\[|\]/g, "").trim(),
+		tag.compilerNode.name?.getText().replace(/\[|\]|(=.*)/g, "").trim(),
 		(tag.getComment() || "").toString().trim().replace(/^[ -]+/, ""),
 	]));
 	const preferredTagName = paramTags[0]?.getTagName();

--- a/index.ts
+++ b/index.ts
@@ -89,32 +89,38 @@ function generateParameterDocumentation(
 	docNode: JSDocableNode,
 ): void {
 	const params = functionNode.getParameters();
+
+	// Get param tag that matches the param
+	const jsDoc = getJsDocOrCreate(functionNode);
+	const paramTags = (jsDoc.getTags() || [])
+		.filter((tag) => ["param", "parameter"].includes(tag.getTagName()));
+	const commentLookup = Object.fromEntries(paramTags.map((tag) => [
+		// @ts-ignore
+		tag.compilerNode.name?.getText().replace(/\[|\]/g, "").trim(),
+		(tag.getComment() || "").toString().trim().replace(/^[ -]+/, ""),
+	]));
+	const preferredTagName = paramTags[0]?.getTagName();
+	paramTags.forEach((tag) => tag.remove());
+
 	for (const param of params) {
 		const parameterType = sanitizeType(param.getTypeNode()?.getText());
 		if (!parameterType) continue;
-		// Get param tag that matches the param
-		const jsDoc = getJsDocOrCreate(docNode);
-		const paramTag = (jsDoc.getTags() || [])
-			.filter((tag) => ["param", "parameter"].includes(tag.getTagName()))
-			// @ts-ignore
-			.find((tag) => tag.compilerNode.name?.getText() === param.getName());
 
 		const paramNameRaw = param.compilerNode.name?.getText();
+		const isOptional = param.hasQuestionToken();
+		let paramName = paramNameRaw;
+		// Wrap name in square brackets if the parameter is optional
+		paramName = isOptional ? `[${paramName}]` : paramName;
 		// Skip parameter names if they are present in the type as an object literal
 		// e.g. destructuring; { a }: { a: string }
-		const paramName = paramNameRaw.match(/[{},]/) ? "" : ` ${paramNameRaw}`;
-		if (paramTag) {
-			// Replace tag with one that contains type info
-			const comment = paramTag.getComment();
-			const tagName = paramTag.getTagName();
+		paramName = paramName.match(/[{},]/) ? "" : ` ${paramName}`;
 
-			paramTag.replaceWithText(`@${tagName} {${parameterType}}${paramName}  ${comment}`);
-		} else {
-			jsDoc.addTag({
-				tagName: "param",
-				text: `{${parameterType}}${paramName}`,
-			});
-		}
+		const comment = commentLookup[paramNameRaw.trim()];
+
+		jsDoc.addTag({
+			tagName: preferredTagName || "param",
+			text: `{${parameterType}}${paramName}${comment ? `  ${comment}` : ""}`,
+		});
 	}
 }
 

--- a/index.ts
+++ b/index.ts
@@ -91,7 +91,7 @@ function generateParameterDocumentation(
 	const params = functionNode.getParameters();
 
 	// Get param tag that matches the param
-	const jsDoc = getJsDocOrCreate(functionNode);
+	const jsDoc = getJsDocOrCreate(docNode);
 	const paramTags = (jsDoc.getTags() || [])
 		.filter((tag) => ["param", "parameter"].includes(tag.getTagName()));
 	const commentLookup = Object.fromEntries(paramTags.map((tag) => [

--- a/index.ts
+++ b/index.ts
@@ -136,22 +136,16 @@ function generateReturnTypeDocumentation(
 	const returnsTag = (jsDoc?.getTags() || [])
 		.find((tag) => ["returns", "return"].includes(tag.getTagName()));
 	// Replace tag with one that contains type info if tag exists
+	const tagName = returnsTag?.getTagName() || "returns";
+	const comment = (returnsTag?.getComment() || "").toString().trim().replace(/^[ -]+/, "");
+
 	if (returnsTag) {
-		const tagName = returnsTag.getTagName();
-		const comment = (returnsTag.getComment() || "").toString().trim().replace(/^[ -]+/, "");
-		// https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#return-type-description
-		if (functionReturnType !== "void") {
-			returnsTag.replaceWithText(
-				`@${tagName} {${functionReturnType}}${comment ? ` - ${comment}` : ""}`,
-			);
-		}
-	} else {
-		// Otherwise, create a new one
-		jsDoc.addTag({
-			tagName: "returns",
-			text: `{${functionReturnType}}`,
-		});
+		returnsTag.remove();
 	}
+	jsDoc.addTag({
+		tagName,
+		text: `{${functionReturnType}}${comment ? ` - ${comment}` : ""}`,
+	});
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -97,7 +97,7 @@ function generateParameterDocumentation(
 	const commentLookup = Object.fromEntries(paramTags.map((tag) => [
 		// @ts-ignore
 		tag.compilerNode.name?.getText().replace(/\[|\]|(=.*)/g, "").trim(),
-		(tag.getComment() || "").toString().trim().replace(/^[ -]+/, ""),
+		(tag.getComment() || "").toString().trim(),
 	]));
 	const preferredTagName = paramTags[0]?.getTagName();
 	paramTags.forEach((tag) => tag.remove());
@@ -134,7 +134,7 @@ function generateParameterDocumentation(
 
 		jsDoc.addTag({
 			tagName: preferredTagName || "param",
-			text: `{${paramTypeOut}}${paramNameOut}${comment ? ` - ${comment}` : ""}`,
+			text: `{${paramTypeOut}}${paramNameOut}${comment ? ` ${comment}` : ""}`,
 		});
 	}
 }
@@ -152,14 +152,14 @@ function generateReturnTypeDocumentation(
 		.find((tag) => ["returns", "return"].includes(tag.getTagName()));
 	// Replace tag with one that contains type info if tag exists
 	const tagName = returnsTag?.getTagName() || "returns";
-	const comment = (returnsTag?.getComment() || "").toString().trim().replace(/^[ -]+/, "");
+	const comment = (returnsTag?.getComment() || "").toString().trim();
 
 	if (returnsTag) {
 		returnsTag.remove();
 	}
 	jsDoc.addTag({
 		tagName,
-		text: `{${functionReturnType}}${comment ? ` - ${comment}` : ""}`,
+		text: `{${functionReturnType}}${comment ? ` ${comment}` : ""}`,
 	});
 }
 

--- a/index.ts
+++ b/index.ts
@@ -103,11 +103,15 @@ function generateParameterDocumentation(
 	paramTags.forEach((tag) => tag.remove());
 
 	for (const param of params) {
-		const parameterType = sanitizeType(param.getTypeNode()?.getText());
-		if (!parameterType) continue;
+		const paramType = sanitizeType(param.getTypeNode()?.getText());
+		if (!paramType) continue;
 
 		const paramName = param.compilerNode.name?.getText();
 		const isOptional = param.isOptional();
+		const isRest = param.isRestParameter();
+
+		// Rest parameters are arrays, but the JSDoc syntax is `...number` instead of `number[]`
+		const paramTypeOut = isRest ? `...${paramType.replace(/\[\]\s*$/, "")}` : paramType;
 
 		let defaultValue: string;
 		if (isOptional) {
@@ -130,7 +134,7 @@ function generateParameterDocumentation(
 
 		jsDoc.addTag({
 			tagName: preferredTagName || "param",
-			text: `{${parameterType}}${paramNameOut}${comment ? ` - ${comment}` : ""}`,
+			text: `{${paramTypeOut}}${paramNameOut}${comment ? ` - ${comment}` : ""}`,
 		});
 	}
 }


### PR DESCRIPTION
Originally part of https://github.com/futurGH/ts-to-jsdoc/pull/22 , _**with additional changes**_

- Support for optional params (both `param?`, and `param = x`), wrapping the output name in square brackets
- Include default values for params where applicable
- Always remove and re-add `@param` and `@return` tags, so that they are always in the correct order
- Support correct JSDoc syntax for rest parameters

Note: this conflicts with https://github.com/futurGH/ts-to-jsdoc/pull/24 which should be merged first, and this PR rebased and updated