### PR TITLE
Place first line of JSDoc after /** line

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -445,6 +445,7 @@ function transpile(
 			if (interfaces) result += `\n\n${interfaces}`;
 
 			result = `${result.trim()}\n`;
+			result = result.replace(/\/\*\* \@([^\n]+)((?:\n \* .+)+)/g, '/**\n * @$1$2');
 
 			return result;
 		}


### PR DESCRIPTION
### PR summary
When there is not a single line, the first line has been modified to appear after /**. 

### cause
The reason is that when using vscode, the first line is treated as a footnote, which is not visually pleasing. Oh, of course, with jsDoc, ctrl + click, intellisense, and documentation work well.

- as-is
![as-is](https://github.com/futurGH/ts-to-jsdoc/assets/84114149/973774ef-1ed1-4ea5-abfa-a8acbd8de93c)

- to-be
![to-be](https://github.com/futurGH/ts-to-jsdoc/assets/84114149/9ce3e0c0-ed80-4bf1-b836-6170f101b768)
