### PR TITLE
refix Place first line of JSDoc after /** line & fix typeof 

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -445,7 +445,8 @@ function transpile(
 			if (interfaces) result += `\n\n${interfaces}`;
 
 			result = `${result.trim()}\n`;
-			result = result.replace(/\/\*\* \@([^\n]+)((?:\n \* .+)+)/g, '/**\n * @$1$2');
+      result = result.replace(/\/\*\* \@([^\n]+)(\n(\s{1,})\* .+)/g, "/**\n$3* @$1$2");
+      result = result.replace(/(typeof)(\S)/, "$1 $2");
 
 			return result;
 		}

--- a/index.ts
+++ b/index.ts
@@ -445,6 +445,7 @@ function transpile(
 			if (interfaces) result += `\n\n${interfaces}`;
 
 			result = `${result.trim()}\n`;
+			result = result.replace(/\/\*\* \@([^\n]+)((?:\n \* .+)+)/g, '/**\n * @$1$2');
 
 			return result;
 		}


### PR DESCRIPTION
### PR summary
When there is not a single line, the first line has been modified to appear after /**.
and when typeof is used, an error occurs with the following text attached.


### cause
The reason is that when using vscode, the first line is treated as a footnote, which is not visually pleasing. Oh, of course, with jsDoc, ctrl + click, intellisense, and documentation work well.
it has problem it can't check in long function or class
`	
let propType = node.getTypeNode()
		?.getText()
		?.replace(/\n/g, "")
		?.replace(/\s/g, "");
`
in generateObjectPropertyDocumentation function

ex) ConstructorParameters<typeof OverviewMap>[0] -> ConstructorParameters<typeofOverviewMap>[0] (it can see in as-is picture)
![as-is](https://github.com/futurGH/ts-to-jsdoc/assets/84114149/fda0c1b1-7ed2-410c-b289-24b679ca8c39)

![to-be](https://github.com/futurGH/ts-to-jsdoc/assets/84114149/80b184b2-c366-4c73-a726-000135f399fa)

### expected result
It may come out like to-be, but I felt that this was not a fundamental solution. Because it doesn't solve potential problems.
