### PR TITLE
Convert ImportDeclaration's into @typedef's

### DIFF
--- a/test/type-imports.test.js
+++ b/test/type-imports.test.js
@@ -1,0 +1,36 @@
+const compareTranspile = require("./compare.js");
+
+describe("type-imports", () => {
+	test("document default type imports", () => {
+		const input = `
+import type ts from "ts-morph";
+`;
+		const expected = `/** @typedef {import('ts-morph')} ts */
+
+export {};
+`;
+		compareTranspile(input, expected);
+	});
+
+	test("document named type imports", () => {
+		const input = `
+import type { ts } from "ts-morph";
+`;
+		const expected = `/** @typedef {import('ts-morph').ts} ts */
+
+export {};
+`;
+		compareTranspile(input, expected);
+	});
+
+	test("document named type imports with alias", () => {
+		const input = `
+import type { ts as TypeScript } from "ts-morph";
+`;
+		const expected = `/** @typedef {import('ts-morph').ts} TypeScript */
+
+export {};
+`;
+		compareTranspile(input, expected);
+	});
+});


### PR DESCRIPTION
Fixes: #15

**test.js**

```js
const transpile = require('./index.js');
const ret = transpile(`
import type {
	ImportDeclaration,
	ClassDeclaration,
	FunctionLikeDeclaration,
	InterfaceDeclaration,
	JSDoc,
	JSDocableNode,
	MethodDeclaration,
	ModifierableNode,
	PropertyAssignment,
	PropertyDeclaration,
	PropertySignature,
	TypeAliasDeclaration,
	TypedNode,
	VariableDeclaration,
} from "ts-morph";

import type {
	A,
	B
} from "abc";

import type * as ABC from "abc";

`);
console.log(ret);
```

Output of `npm run build && node test.js`:

```js
/** @typedef {import('ts-morph').ImportDeclaration} ImportDeclaration */
/** @typedef {import('ts-morph').ClassDeclaration} ClassDeclaration */
/** @typedef {import('ts-morph').FunctionLikeDeclaration} FunctionLikeDeclaration */
/** @typedef {import('ts-morph').InterfaceDeclaration} InterfaceDeclaration */
/** @typedef {import('ts-morph').JSDoc} JSDoc */
/** @typedef {import('ts-morph').JSDocableNode} JSDocableNode */
/** @typedef {import('ts-morph').MethodDeclaration} MethodDeclaration */
/** @typedef {import('ts-morph').ModifierableNode} ModifierableNode */
/** @typedef {import('ts-morph').PropertyAssignment} PropertyAssignment */
/** @typedef {import('ts-morph').PropertyDeclaration} PropertyDeclaration */
/** @typedef {import('ts-morph').PropertySignature} PropertySignature */
/** @typedef {import('ts-morph').TypeAliasDeclaration} TypeAliasDeclaration */
/** @typedef {import('ts-morph').TypedNode} TypedNode */
/** @typedef {import('ts-morph').VariableDeclaration} VariableDeclaration */
/** @typedef {import('abc').A} A */
/** @typedef {import('abc').B} B */
/** @typedef {import('abc')} ABC */
export {};
```

Previous output was:

```js
export {};
```
