### PR TITLE
Prettier and Ts-Jest

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,8 +3,12 @@
 		"es2021": true,
 		"node": true,
 		"jest/globals": true
-    },
-	"extends": ["airbnb-base", "plugin:@typescript-eslint/recommended"],
+	},
+	"extends": [
+		"airbnb-base",
+		"prettier",
+		"plugin:@typescript-eslint/recommended"
+	],
 	"parser": "@typescript-eslint/parser",
 	"parserOptions": {
 		"ecmaVersion": 12,

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+	"trailingComma": "es5",
+	"useTabs": true,
+	"semi": true
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	transform: {
+		"^.+\\.tsx?$": "ts-jest",
+	},
+	testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+	moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+	collectCoverage: true,
+};

--- a/test/compare.js
+++ b/test/compare.js
@@ -1,4 +1,4 @@
-const transpile = require("../index.js");
+const transpile = require("../index.ts");
 
 /**
  * Compare the transpiled output of the input to the expected output.


### PR DESCRIPTION
Problem: 
I was trying to understand the code and I used the debugger to help me.
After some hours trying to understand why the _breakpoints_ weren't working I figured out that it was because of typescript.

I use prettier as formatter so the code was formatting automatically,

Solution:
Install ts-jest
Create an standard for format the code

Funny observation:
The feature I was trying to add was about type imports that the maintainer add to the project 3 days ago LOL.