### PR TITLE
configures transpileFile to use in memory fs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -554,6 +554,7 @@ export function transpileFile(
 				target: ScriptTarget.ESNext,
 				esModuleInterop: true,
 			},
+			useInMemoryFileSystem: true,
 			compilerOptions,
 		});
 


### PR DESCRIPTION
This PR adjusts the typescript project in transpileFile to use an in memory file system. This opens the possibility of using ts-to-jsdoc directly in the browser (with an import map and path polyfill).

Resolves https://github.com/futurGH/ts-to-jsdoc/issues/45
Related to https://github.com/futurGH/ts-to-jsdoc/pull/46
Closes #46