### PR TITLE
Use @import JSDoc tags for TypeScript >= 5.5

### DIFF
--- a/test/compare.js
+++ b/test/compare.js
@@ -4,9 +4,10 @@ const { transpileFile } = require("../index.js");
  * Compare the transpiled output of the input to the expected output.
  * @param {string} input The input to transpile.
  * @param {string} expected The expected output.
+ * @param {string} tsVersion The TypeScript version to use. Defaults to 4.9.
  */
-function compareTranspile(input, expected) {
-	const actual = transpileFile({ code: input });
+function compareTranspile(input, expected, tsVersion = "4.9") {
+	const actual = transpileFile({ code: input, tsVersion });
 
 	expect(actual).toBe(expected);
 }

--- a/test/type-imports.test.js
+++ b/test/type-imports.test.js
@@ -1,52 +1,53 @@
 const compareTranspile = require("./compare.js");
 
 describe("type-imports", () => {
-	test("document default type imports", () => {
-		const input = `
+	describe("uses @typedef for TS versions < 5.5", () => {
+		test("document default type imports", () => {
+			const input = `
 import type ts from "ts-morph";
 `;
-		const expected = `/** @typedef {import('ts-morph')} ts */
+			const expected = `/** @typedef {import('ts-morph')} ts */
 export {};
 `;
-		compareTranspile(input, expected);
-	});
+			compareTranspile(input, expected, "5.4");
+		});
 
-	test("document named type imports", () => {
-		const input = `
+		test("document named type imports", () => {
+			const input = `
 import type { ts } from "ts-morph";
 `;
-		const expected = `/** @typedef {import('ts-morph').ts} ts */
+			const expected = `/** @typedef {import('ts-morph').ts} ts */
 export {};
 `;
-		compareTranspile(input, expected);
-	});
+			compareTranspile(input, expected, "5.4");
+		});
 
-	test("document named type imports with alias", () => {
-		const input = `
+		test("document named type imports with alias", () => {
+			const input = `
 import type { ts as TypeScript } from "ts-morph";
 `;
-		const expected = `/** @typedef {import('ts-morph').ts} TypeScript */
+			const expected = `/** @typedef {import('ts-morph').ts} TypeScript */
 export {};
 `;
-		compareTranspile(input, expected);
-	});
+			compareTranspile(input, expected, "5.4");
+		});
 
-	test("document named type imports but not default value import", () => {
-		const input = `
+		test("document named type imports but not default value import", () => {
+			const input = `
 import ts, { type Node } from "ts-morph";
 `;
-		const expected = `/** @typedef {import('ts-morph').Node} Node */
+			const expected = `/** @typedef {import('ts-morph').Node} Node */
 export {};
 `;
-		compareTranspile(input, expected);
-	});
+			compareTranspile(input, expected, "5.4");
+		});
 
-	test("document value imports if used only in a type position", () => {
-		const input = `
+		test("document value imports if used only in a type position", () => {
+			const input = `
 import { Node } from "ts-morph";
 function foo(node: Node) {}
-`;
-		const expected = `/** @typedef {import('ts-morph').Node} Node */
+	`;
+			const expected = `/** @typedef {import('ts-morph').Node} Node */
 /**
  * @param {Node} node
  * @returns {void}
@@ -54,6 +55,64 @@ function foo(node: Node) {}
 function foo(node) { }
 export {};
 `;
-		compareTranspile(input, expected);
+			compareTranspile(input, expected, "5.4");
+		});
+	});
+	describe("uses @import for TS versions >= 5.5", () => {
+		test("document default type imports", () => {
+			const input = `
+import type ts from "ts-morph";
+`;
+			const expected = `/** @import ts from 'ts-morph' */
+export {};
+`;
+			compareTranspile(input, expected, "5.5");
+		});
+
+		test("document named type imports", () => {
+			const input = `
+import type { ts } from "ts-morph";
+`;
+			const expected = `/** @import { ts } from 'ts-morph' */
+export {};
+`;
+			compareTranspile(input, expected, "5.5");
+		});
+
+		test("document named type imports with alias", () => {
+			const input = `
+import type { ts as TypeScript } from "ts-morph";
+`;
+			const expected = `/** @import { ts as TypeScript } from 'ts-morph' */
+export {};
+`;
+			compareTranspile(input, expected, "5.5");
+		});
+
+		test("document named type imports but not default value import", () => {
+			const input = `
+import ts, { type Node } from "ts-morph";
+`;
+			const expected = `/** @import { Node } from 'ts-morph' */
+export {};
+`;
+			compareTranspile(input, expected, "5.5");
+		});
+
+		test("document value imports if used only in a type position", () => {
+			const input = `
+import { Node } from "ts-morph";
+function foo(node: Node) {}
+	`;
+			const expected = `/** @import { Node } from 'ts-morph' */
+/**
+ * @param {Node} node
+ * @returns {void}
+ */
+function foo(node) { }
+export {};
+`;
+			compareTranspile(input, expected, "5.5");
+		});
 	});
 });


### PR DESCRIPTION
These are easier to read than the `/** @typedef */` workaround, and also take up less space. For each import, a separate `@typedef` is required.

TypeScript supports `/** @import */` since version 5.5, see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#the-jsdoc-import-tag

I changed it so that it detects the current TypeScript version and uses `@typedef` for version < 5.5, and `@import` for versions >= 5.5. Perhaps you could also add an option for which import style to use, but I prefer less options, and `@import` seems like the proper way if supported. `transpileFile` has an optional `tsVersion` argument, which is needed for tests and could also be used by consumers if needed.

![image](https://github.com/user-attachments/assets/76418a79-6548-4591-b121-8df1b705a1f9)
